### PR TITLE
Fixed null city issue and renamed variables for location services

### DIFF
--- a/app/src/main/java/com/example/whattowear/MainActivity.java
+++ b/app/src/main/java/com/example/whattowear/MainActivity.java
@@ -4,7 +4,6 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.Manifest;
-import android.annotation.SuppressLint;
 import android.location.Address;
 import android.location.Geocoder;
 import android.location.Location;
@@ -14,15 +13,12 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.codepath.asynchttpclient.AsyncHttpClient;
-import com.codepath.asynchttpclient.RequestParams;
 import com.codepath.asynchttpclient.callback.JsonHttpResponseHandler;
-import com.codepath.asynchttpclient.callback.TextHttpResponseHandler;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.tasks.OnSuccessListener;
 
 import org.json.JSONException;
-import org.w3c.dom.Text;
 
 import java.io.IOException;
 import java.util.List;
@@ -37,10 +33,10 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
     public static final int PERMISSIONS_REQUEST_CODE = 1;
 
     private FusedLocationProviderClient fusedLocationClient;
-    private AsyncHttpClient openweatherClient;
+    private AsyncHttpClient openWeatherClient;
     private Location lastLocation;
     private TextView locationTextview;
-    private String units;
+    private String weatherUnits;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -50,10 +46,10 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
         // initialize fused location client
         // does not need permissions
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
-        openweatherClient = new AsyncHttpClient();
+        openWeatherClient = new AsyncHttpClient();
 
         // TODO: Change this to get from Parse database
-        units = "imperial";
+        weatherUnits = "imperial";
 
         locationTextview = findViewById(R.id.location_textview);
 
@@ -140,8 +136,8 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
                             if (location != null) {
                                 lastLocation = location;
 
-                                String city_name = getLocationName(location);
-                                locationTextview.setText(city_name);
+                                String locationName = getLocationName(location);
+                                locationTextview.setText(locationName);
                                 getWeatherAtLastLocation();
                             } else {
                                 // TODO: Handle no location found
@@ -165,19 +161,19 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
 
         Geocoder geoCoder = new Geocoder(this, Locale.getDefault());
         StringBuilder builder = new StringBuilder();
-        String loc_name = "";
+        String locationName = "";
         try {
             List<Address> address = geoCoder.getFromLocation(latitude, longitude, 1);
             // set depending on what is known
             if (address.get(0).getLocality() != null) {
-                loc_name = address.get(0).getLocality();
+                locationName = address.get(0).getLocality();
             } else if (address.get(0).getSubAdminArea() != null) {
-                loc_name = address.get(0).getSubAdminArea();
+                locationName = address.get(0).getSubAdminArea();
             } else if (address.get(0).getAdminArea() != null) {
-                loc_name = address.get(0).getAdminArea();
+                locationName = address.get(0).getAdminArea();
             } else if (address.get(0).getCountryName() != null) {
                 // Worst case, try to use country name
-                loc_name = address.get(0).getCountryName();
+                locationName = address.get(0).getCountryName();
             }
         } catch (IOException e) {
             Log.e(TAG, "IOException", e);
@@ -187,11 +183,11 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
 
         // TODO: Fix city being unknown
         // if city still blank, worst case, set to long lat?
-        if (loc_name.isEmpty()) {
-            loc_name = "Lat: " + latitude + "Long: " + longitude;
+        if (locationName.isEmpty()) {
+            locationName = "Lat: " + latitude + "Long: " + longitude;
         }
 
-        return loc_name;
+        return locationName;
     }
 
     /**
@@ -208,14 +204,14 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
         double longitude = lastLocation.getLongitude();
 
         // TODO: Exclude non needed data after detailed weather screen is built
-        String api_url = "https://api.openweathermap.org/data/3.0/onecall?"
+        String apiUrl = "https://api.openweathermap.org/data/3.0/onecall?"
                 + "lat=" + latitude
                 + "&lon=" + longitude
                 + "&lon=" + longitude
-                + "&units=" + units
+                + "&units=" + weatherUnits
                 + "&appid=" + BuildConfig.OPENWEATHER_API_KEY;
 
-        openweatherClient.get(api_url, new JsonHttpResponseHandler() {
+        openWeatherClient.get(apiUrl, new JsonHttpResponseHandler() {
             @Override
             public void onSuccess(int statusCode, Headers headers, JSON json) {
                 // TODO: Update weather data here

--- a/app/src/main/java/com/example/whattowear/MainActivity.java
+++ b/app/src/main/java/com/example/whattowear/MainActivity.java
@@ -37,7 +37,7 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
     public static final int PERMISSIONS_REQUEST_CODE = 1;
 
     private FusedLocationProviderClient fusedLocationClient;
-    AsyncHttpClient openweatherClient;
+    private AsyncHttpClient openweatherClient;
     private Location lastLocation;
     private TextView locationTextview;
     private String units;
@@ -187,7 +187,7 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
 
         // TODO: Fix city being unknown
         // if city still blank, worst case, set to long lat?
-        if (loc_name == "") {
+        if (loc_name.isEmpty()) {
             loc_name = "Lat: " + latitude + "Long: " + longitude;
         }
 


### PR DESCRIPTION
## Overview:

Functionally, the location being displayed to demonstrate the location services functionality remains the same as in the main branch. The changes here are to address the comments in the last code review.

## Solution: 

In the getCityName function (renamed to getLocationName), returning the city name is changed with returning the known name that most identifies the location. The name could be, in order of which exists first: locality, sub admin area, admin area, country name, long/lat coordinates. This avoids the issue where the city name is unknown and is set to null. Associated variable/function names with city are changed to location, where appropriate. 

Variables with snake case are also replaced with lower camel case.

## Demo:

The location services permissions request on different responses look like: 

When accepting while using app:
<img src='https://user-images.githubusercontent.com/17736280/174406454-4ed93ed2-51e1-4e4a-ac52-05cb0b682eea.gif' width='300' alt='whileusing'>

When accepting location services request once
<img src='https://user-images.githubusercontent.com/17736280/174406447-110d4903-deba-4b7a-81f7-0ce798744344.gif' width='300' alt='onlythistime'>

When denying location services request:
<img src='https://user-images.githubusercontent.com/17736280/174406443-89632fca-6f73-447b-bec7-5b5797940395.gif' width='300' alt='dontallow'>


Once permanently denied, the app will not ask for permission again:
<img src='https://user-images.githubusercontent.com/17736280/174406705-afa962da-e8cd-4564-914e-09bf9e91ccb6.gif' width='300' alt='permanentdeny'>

The app will not function until the location services permission is granted.

